### PR TITLE
Fix parser unpacking bug and update to GPT-4.1 models (#35)

### DIFF
--- a/src/pipeline_v3/CLAUDE.md
+++ b/src/pipeline_v3/CLAUDE.md
@@ -330,7 +330,7 @@ uv run python -m src.pipeline_v3.cli_main search "PM10" --type keyword
 ## Key Configuration
 
 Configuration via `config.yaml`:
-- **OpenAI Models:** gpt-4o for vision, text-embedding-3-small for embeddings
+- **OpenAI Models:** gpt-4.1 for vision, gpt-4.1-mini for keywords, text-embedding-3-small for embeddings
 - **Qdrant Settings:** `./qdrant_data_v3`, collection: `datasheets_v3`, dimensions: 1536
 - **Storage:** `./storage_data_v3` (JSONL artifacts with full datasheet content)
 - **Cache:** LZ4 compression, configurable TTL

--- a/src/pipeline_v3/cli_main.py
+++ b/src/pipeline_v3/cli_main.py
@@ -10,7 +10,7 @@ Usage:
 This is a convenience script that imports and runs the main CLI.
 """
 
-from utils.common_utils import init_cli_logging, CLIArgumentError, DependencyError, ConfigLoadError
+from .utils.common_utils import init_cli_logging, CLIArgumentError, DependencyError, ConfigLoadError
 
 # Initialize logging first
 init_cli_logging()
@@ -23,8 +23,8 @@ from pathlib import Path
 # Add the current directory to Python path
 sys.path.insert(0, str(Path(__file__).parent))
 
-from cli.management import main
-from utils.cleanup import cleanup_temp_resources, get_resource_manager
+from .cli.management import main
+from .utils.cleanup import cleanup_temp_resources, get_resource_manager
 
 logger = logging.getLogger(__name__)
 

--- a/src/pipeline_v3/core/parsers.py
+++ b/src/pipeline_v3/core/parsers.py
@@ -225,7 +225,7 @@ async def parse_document(
 
     elif doc_type == DocumentType.DATASHEET_PDF:
         # Use special datasheet prompt with pair extraction
-        markdown, pairs = await vision_parse_datasheet(pdf_path, prompt_text, config)
+        markdown, pairs, _ = await vision_parse_datasheet(pdf_path, prompt_text, config)
         metadata = {
             "source_type": "datasheet_pdf", 
             "extracted_pairs": len(pairs),
@@ -237,7 +237,7 @@ async def parse_document(
 
     elif doc_type == DocumentType.GENERIC_PDF:
         # Use generic prompt without pair extraction
-        markdown, _ = await vision_parse_generic(pdf_path, prompt_text, config)
+        markdown, _, _ = await vision_parse_generic(pdf_path, prompt_text, config)
         pairs = []
         metadata = {
             "source_type": "generic_pdf",
@@ -249,7 +249,7 @@ async def parse_document(
 
     elif doc_type == DocumentType.WORD_DOCUMENT:
         # Parse Word document with python-docx
-        markdown, pairs = await parse_word_document(pdf_path, config)
+        markdown, pairs, _ = await parse_word_document(pdf_path, config)
         metadata = {
             "source_type": "word_document",
             "file_name": pdf_path.name,
@@ -289,17 +289,17 @@ async def parse_document(
             {"markdown": markdown, "pairs": pairs, "metadata": metadata},
         )
 
-    return markdown, pairs, metadata, metadata
+    return markdown, pairs, metadata
 
 
 async def vision_parse_datasheet(
     pdf: Path, parsing_prompt: str, config: Optional[PipelineConfig] = None
-) -> Tuple[str, List[Tuple[str, str]]]:
+) -> Tuple[str, List[Tuple[str, str]], Dict[str, Any]]:
     """Parse datasheet PDF with model/part number extraction."""
     client = OpenAI()
 
     # Get model from config or use default
-    model = config.openai.vision_model if config else "gpt-4o"
+    model = config.openai.vision_model if config else "gpt-4.1"
     max_retries = config.openai.max_retries if config else 3
 
     # Enhanced prompt structure from notebook
@@ -382,17 +382,19 @@ async def vision_parse_datasheet(
         logger.debug(f"Metadata section being parsed: {md[:200]}...")
         pairs = []
 
-    return md, pairs
+    # Return 3 values to match expected interface
+    # Third value is metadata dict (empty for PDFs as metadata is in pairs)
+    return md, pairs, {}
 
 
 async def vision_parse_generic(
     pdf: Path, parsing_prompt: str, config: Optional[PipelineConfig] = None
-) -> Tuple[str, List[Tuple[str, str]]]:
+) -> Tuple[str, List[Tuple[str, str]], Dict[str, Any]]:
     """Parse generic PDF without pair extraction."""
     client = OpenAI()
 
     # Get model from config or use default
-    model = config.openai.vision_model if config else "gpt-4o"
+    model = config.openai.vision_model if config else "gpt-4.1"
     max_retries = config.openai.max_retries if config else 3
 
     # Enhanced prompt for generic PDFs
@@ -430,7 +432,9 @@ async def vision_parse_generic(
         )
 
     response = await call_api()
-    return response.output[0].content[0].text, []
+    # Return 3 values to match expected interface
+    # Generic PDFs don't extract pairs, so return empty list and dict
+    return response.output[0].content[0].text, [], {}
 
 
 async def parse_word_document(

--- a/src/pipeline_v3/utils/chunking_metadata.py
+++ b/src/pipeline_v3/utils/chunking_metadata.py
@@ -13,7 +13,7 @@ from .common_utils import logger, retry_api_call
 class KeywordGenerator:
     """Generate contextual keywords for document chunks using OpenAI."""
     
-    def __init__(self, model: str = "gpt-4o-mini", max_keywords: int = 10):
+    def __init__(self, model: str = "gpt-4.1-mini", max_keywords: int = 10):
         self.client = OpenAI()
         self.model = model
         self.max_keywords = max_keywords
@@ -92,7 +92,7 @@ Return only a JSON list of keywords, like: ["keyword1", "keyword2", ...]"""
 
 async def batch_generate_keywords(
     nodes: List[TextNode], 
-    model: str = "gpt-4o-mini",
+    model: str = "gpt-4.1-mini",
     batch_size: int = 10
 ) -> List[TextNode]:
     """Generate keywords for multiple nodes in batches for cost efficiency."""
@@ -234,7 +234,7 @@ async def process_and_index_document(
         if progress:
             progress.update_stage(doc_id, "keywords")
         # Get model from config or use default
-        keyword_model = config.openai.keyword_model if config else "gpt-4o-mini"
+        keyword_model = config.openai.keyword_model if config else "gpt-4.1-mini"
         batch_threshold = config.batch.threshold if config else 10
         
         if len(nodes) > batch_threshold:  # Use batch for large documents

--- a/src/pipeline_v3/utils/config.py
+++ b/src/pipeline_v3/utils/config.py
@@ -43,8 +43,8 @@ class BatchSettings:
 @dataclass
 class OpenAISettings:
     api_key: Optional[str] = None
-    vision_model: str = "gpt-4o"
-    keyword_model: str = "gpt-4o-mini"
+    vision_model: str = "gpt-4.1"
+    keyword_model: str = "gpt-4.1-mini"
     embedding_model: str = "text-embedding-3-small"
     dimensions: int = 1536
     max_retries: int = 3


### PR DESCRIPTION
## Summary
This PR fixes the critical parser unpacking bug that was preventing PDF document processing and updates all model references to use GPT-4.1.

## Changes Made
1. **Fixed parser return values**:
   - `vision_parse_datasheet` now returns 3 values (was 2)
   - `vision_parse_generic` now returns 3 values (was 2)
   - Fixed duplicate metadata return in `parse_document`

2. **Fixed unpacking statements**:
   - Updated `parse_document` to unpack 3 values from PDF parsers
   - Fixed `parse_word_document` unpacking

3. **Updated OpenAI models**:
   - Vision model: `gpt-4o` → `gpt-4.1`
   - Keyword model: `gpt-4o-mini` → `gpt-4.1-mini`
   - Updated all fallback values in code
   - Updated documentation to reflect correct models

## Testing
- ✅ Tested datasheet parsing with `--mode datasheet`
- ✅ Tested keyword generation with `--with-keywords`
- ✅ Verified model/part number extraction works correctly
- ✅ Confirmed both GPT-4.1 models are being used

## Example Output
Successfully extracted pairs:
- PM10K+ DB-25 + USB → PN 2293937
- PM10K+ RS-232 → PN 2293938

Keywords are correctly generated and injected into documents.

Fixes #35